### PR TITLE
Update utils.bash | aarch64 (Amazon Linux 2023)

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -65,6 +65,7 @@ get_arch() {
 
   case "$(uname -m)" in
   x86_64 | amd64) arch="x86_64" ;;
+  aarch64) arch="aarch64" ;; # Amazon Linux 2023
   *)
     fail "Arch '$(uname -m)' not supported!"
     ;;


### PR DESCRIPTION
The function get_arch() has been updated to accommodate the aarch64 (Amazon Linux 2023) architecture in addition to the existing x86_64 and amd64 architectures.